### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,3 +200,10 @@ if(CATKIN_ENABLE_TESTING)
       ${OpenCV_LIBRARIES}
   )
 endif()
+
+install(
+    TARGETS
+        stream
+    DESTINATION
+        ${CATKIN_PACKAGE_BIN_DESTINATION}
+)


### PR DESCRIPTION
When using catkin_make install, the stream executable was not copied to the install folder.